### PR TITLE
Correcting post request for full-text annotation.

### DIFF
--- a/sherlok.py
+++ b/sherlok.py
@@ -28,7 +28,7 @@ class Sherlok(object):
 
         resp = requests.post(
             'http://{}:{}/annotate/{}'.format(self.host, self.port, self.pipeline),
-            params={'text': text})
+            data={'text': text})
         if resp.status_code != 200:
             raise Exception('Sherlok error: {} {}'.format(resp.status_code, resp.text))
         json = resp.json()


### PR DESCRIPTION
The 'params' argument use a get-style encoding which create prohibitively long URI [crash] when using full texts. The 'data' argument must be used instead to pass the text with post-style encoding.
